### PR TITLE
fix: replace deprecated gradle-build-action with gradle/actions/setup-gradle in release job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,7 +72,7 @@ jobs:
           distribution: 'adopt'
 
       - name: Setup Gradle
-        uses: gradle/gradle-build-action@ac2d340dc04d9e1113182899e983b5400c17cda1 # v3.5.0
+        uses: gradle/actions/setup-gradle@39e147cb9de83bb9910b8ef8bd7fff0ee20fcd6f # v6.0.1
         with:
           gradle-home-cache-cleanup: true
       - name: Login to GitHub Container Registry


### PR DESCRIPTION
## Root Cause

The `release` job was using the deprecated `gradle/gradle-build-action@v3.5.0` action. During its post-cleanup step, this action runs a dummy Gradle project using Gradle 9.x. That project's `init.gradle` tries to **read** the `removeUnusedEntriesOlderThan` property, which became **write-only** in Gradle 9.x:

```
Cannot get the value of write-only property 'removeUnusedEntriesOlderThan' for object of type
org.gradle.api.internal.cache.DefaultCacheConfigurations$DefaultCacheResourceConfiguration.
```

This caused the `Post Setup Gradle` step to fail, failing the entire `release` job.

## Fix

Replace `gradle/gradle-build-action@v3.5.0` with `gradle/actions/setup-gradle@v6.0.1` in the `release` job — the same action already used successfully in the `build_linux` job.

## Change

`.github/workflows/build.yml` — one line change in the `release` job's Setup Gradle step.